### PR TITLE
Fix ssh-agent plugin with custom ssh-add location

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/ssh-add $HOME/.ssh/${^identities}
+  /usr/bin/env ssh-add $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from


### PR DESCRIPTION
The ssh-agent plugin assumes ssh-add is located in /usr/bin.
This is not true on all systems (e.g. NixOS).
Instead we call /usr/bin/env to determine ssh-add location.
The plugin already does this in the same function to call ssh-agent.
